### PR TITLE
A more idiomatic failing test for practice

### DIFF
--- a/message_handler.go
+++ b/message_handler.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"io"
+	"net/http"
+)
+
+func handleMessages(w http.ResponseWriter, req *http.Request) {
+	io.WriteString(w, `["something","anything"]`)
+}
+
+func handleMessage(w http.ResponseWriter, req *http.Request) {
+	io.WriteString(w, `"hello"`)
+}

--- a/message_handler_test.go
+++ b/message_handler_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestMessageHandler(t *testing.T) {
+
+	Convey("Returns single message json", t, func() {
+		mockWriter := httptest.NewRecorder()
+		mockRequest := &http.Request{}
+		handleMessage(mockWriter, mockRequest)
+		So(mockWriter.Body.String(), ShouldEqual, `"message": {"id": 1, "body": "stuff"}`)
+	})
+
+	Convey("returns a json array of messages", t, nil)
+
+}

--- a/message_handler_test.go
+++ b/message_handler_test.go
@@ -12,9 +12,9 @@ func TestMessageHandler(t *testing.T) {
 
 	Convey("Returns single message json", t, func() {
 		mockWriter := httptest.NewRecorder()
-		mockRequest := &http.Request{}
-		handleMessage(mockWriter, mockRequest)
-		So(mockWriter.Body.String(), ShouldEqual, `"message": {"id": 1, "body": "stuff"}`)
+		mockRequest := &http.Request{}                                                     // A blank request is sufficient for this test
+		handleMessage(mockWriter, mockRequest)                                             // The actual function under test
+		So(mockWriter.Body.String(), ShouldEqual, `"message": {"id": 1, "body": "stuff"}`) // Because the function doesn't return anything, we're actually testing side-effects
 	})
 
 	Convey("returns a json array of messages", t, nil)

--- a/server.go
+++ b/server.go
@@ -1,18 +1,9 @@
 package main
 
 import (
-	"io"
 	"log"
 	"net/http"
 )
-
-func handleMessages(w http.ResponseWriter, req *http.Request) {
-	io.WriteString(w, `["something","anything"]`)
-}
-
-func handleMessage(w http.ResponseWriter, req *http.Request) {
-	io.WriteString(w, `"hello"`)
-}
 
 func main() {
 	http.HandleFunc("/messages", handleMessages)


### PR DESCRIPTION
Fellow humans :smiling_imp: 

I have taken the liberty of adjusting the test suite to be more idiomatic Go.  I've left you with a failing test example that shows how to test handlers in isolation.

Your challenge now is to make it pass and then write the array test.

I've also made the JSON {json:api} compliant and I recommend reading this http://jsonapi.org/ as it will ensure that your API is readily extensible.  Main learning is that objects should always be wrapped in a key that defines what it is, rather than sending an anonymous object.

As we discussed at the lunch and learn, the server test probably is a bit brittle and `go test` should not require the server running in order to execute the test suite, this is more in the vein of an integration test an should be a thing in its own right.
